### PR TITLE
FLASH_SIZE is reserved, at least for SAMD boards. 

### DIFF
--- a/ArduinoBoardManager.h
+++ b/ArduinoBoardManager.h
@@ -102,105 +102,109 @@ class ArduinoBoardManager {
   static const uint16_t CPU = __AVR_ATmega328P__;     /**< 16Mhz */
   static const unsigned long SRAM_SIZE = 2000;       /**< 2kb of sram */
   static const unsigned long EEPROM_SIZE = 1000;     /**< 1kb eeprom */
-  static const unsigned long FLASH_SIZE = 32000;     /**< 32k flash storage */
+  static const unsigned long BOARD_FLASH_SIZE = 32000;     /**< 32k flash storage */
 #elif defined(__AVR_ATSAMD21G18A__) // zero
   static const uint8_t BOARD = BOARD_ZERO
   static const uint8_t NUM_BITS = 8;
   static const uint16_t CPU = __AVR_ATSAMD21G18A__;
   static const unsigned long SRAM_SIZE = 32000;
   static const unsigned long EEPROM_SIZE = 16000;
-  static const unsigned long FLASH_SIZE = 256000;
+  static const unsigned long BOARD_FLASH_SIZE = 256000;
 #elif defined(__AVR_ATSAM3X8E__) // Due
   static const uint8_t BOARD = BOARD_DUE;
   static const uint8_t NUM_BITS = 8;
   static const uint16_t CPU = __AVR_ATSAMD21G18A__;
   static const unsigned long SRAM_SIZE = 96000;
   static const unsigned long EEPROM_SIZE = 0;
-  static const unsigned long FLASH_SIZE = 512000;
+  static const unsigned long BOARD_FLASH_SIZE = 512000;
 #elif defined(__AVR_ATmega32U4__) // Yun 16Mhz, Micro, Leonardo, Esplora
   static const uint8_t BOARD = BOARD_MICRO;
   static const uint8_t NUM_BITS = 8;
   static const uint16_t CPU = __AVR_Atmega32U4__;
   static const unsigned long SRAM_SIZE = 2500;
   static const unsigned long EEPROM_SIZE = 1000;
-  static const unsigned long FLASH_SIZE = 32000;
+  static const unsigned long BOARD_FLASH_SIZE = 32000;
 #elif defined(_AVR_AR9331__) // Yun 400Mhz
   static const uint8_t BOARD = BOARD_YUN_400;
   static const uint8_t NUM_BITS = 8;
   static const uint16_t CPU = _AVR_AR9331__;
   static const unsigned long SRAM_SIZE = 64000000;
   static const unsigned long EEPROM_SIZE = 0;
-  static const unsigned long FLASH_SIZE = 16000000;
+  static const unsigned long BOARD_FLASH_SIZE = 16000000;
 #elif defined(__AVR_ATmega16U4__) // leonardo
   static const uint8_t BOARD = BOARD_LEONARDO;
   static const uint8_t NUM_BITS = 8;
   static const uint16_t CPU = __AVR_ATmega16U4__;
   static const unsigned long SRAM_SIZE = 2560;
   static const unsigned long EEPROM_SIZE = 1000;
-  static const unsigned long FLASH_SIZE = 32000;
+  static const unsigned long BOARD_FLASH_SIZE = 32000;
 #elif defined(__AVR_ATmega1280__) // mega, Mega ADK (ATmega 1280)
   static const uint8_t BOARD = BOARD_MEGA_1280;
   static const uint8_t NUM_BITS = 8;
   static const uint16_t CPU = __AVR_ATmega1280__;
   static const unsigned long SRAM_SIZE = 8000;
   static const unsigned long EEPROM_SIZE = 4000;
-  static const unsigned long FLASH_SIZE = 256000;
+  static const unsigned long BOARD_FLASH_SIZE = 256000;
 #elif defined(__AVR_ATmega2560__) // mega, Mega ADK (ATmega 2560)
     static const uint8_t BOARD = BOARD_MEGA_2560;
     static const uint8_t NUM_BITS = 8;
     static const uint16_t CPU = __AVR_ATmega2560__;
     static const unsigned long SRAM_SIZE = 8000;
     static const unsigned long EEPROM_SIZE = 4000;
-    static const unsigned long FLASH_SIZE = 256000;
+    static const unsigned long BOARD_FLASH_SIZE = 256000;
 #elif defined(_AVR_ATmega328__) // Nano >= v3.0 or Arduino Pro, pro328, ethernet
   static const uint8_t BOARD = BOARD_NANO;
   static const uint8_t NUM_BITS = 8;
   static const uint16_t CPU = _AVR_ATmega328__;
   static const unsigned long SRAM_SIZE = 2000;
   static const unsigned long EEPROM_SIZE = 1000;
-  static const unsigned long FLASH_SIZE = 32000;
+  static const unsigned long BOARD_FLASH_SIZE = 32000;
 #elif defined(_AVR_ATmega168__) // Nano < v3.0 or uno, pro
   static const uint8_t BOARD = BOARD_NANO_3;
   static const uint8_t NUM_BITS = 8;
   static const uint16_t CPU = _AVR_ATmega168;
   static const unsigned long SRAM_SIZE = 1000;
   static const unsigned long EEPROM_SIZE = 500;
-  static const unsigned long FLASH_SIZE = 16000;
+  static const unsigned long BOARD_FLASH_SIZE = 16000;
 #elif defined(_AVR_ATmega168V__) // LilyPad
   static const uint8_t BOARD = BOARD_LILYPAD;
   static const uint8_t CPU = _AVR_ATmega168V__;
   static const unsigned int NUM_BITS = 8;
   static const unsigned long SRAM_SIZE = 1000;
   static const unsigned long EEPROM_SIZE = 500;
-  static const unsigned long FLASH_SIZE = 14000
+  static const unsigned long BOARD_FLASH_SIZE = 14000
 #elif defined(_AVR_ATmega328V__) // LilyPad 2
   static const uint8_t BOARD = BOARD_LILYPAD_2;
   static const uint8_t CPU = _AVR_ATmega328V__;
   static const unsigned int NUM_BITS = 8;
   static const unsigned long SRAM_SIZE = 1000;
   static const unsigned long EEPROM_SIZE = 500;
-  static const unsigned long FLASH_SIZE = 14000
+  static const unsigned long BOARD_FLASH_SIZE = 14000
 #elif defined(_AVR_ATTiny85__) // trinket
   static const uint8_t BOARD = BOARD_TRINKET;
   static const uint8_t NUM_BITS = 8;
   static const uint16_t CPU = _AVR_ATTiny85__;
   static const unsigned long SRAM_SIZE = 500;
   static const unsigned long EEPROM_SIZE = 500;
-  static const unsigned long FLASH_SIZE = 2500;
+  static const unsigned long BOARD_FLASH_SIZE = 2500;
 #elif  defined(__AVR_ARCv2EM__) || (__CURIE_FACTORY_DATA_H_) // Intel Curie/101
   static const uint8_t BOARD = BOARD_101;
   static const uint8_t NUM_BITS = 32;
   static const uint16_t CPU = __AVR_ARCv2EM__;
   static const unsigned long SRAM_SIZE = 24000; // might be 80k?
   static const unsigned long EEPROM_SIZE = 0;
-  static const unsigned long FLASH_SIZE = 384000;
+  static const unsigned long BOARD_FLASH_SIZE = 384000;
 #else
   static const uint8_t BOARD = BOARD_UNKNOWN;
   static const uint8_t NUM_BITS = 0;
   static const uint16_t CPU = 0;
   static const unsigned long SRAM_SIZE = 0;
   static const unsigned long EEPROM_SIZE = 0;
-  static const unsigned long FLASH_SIZE = 0;
+#if !defined(FLASH_SIZE)
+  static const unsigned long BOARD_FLASH_SIZE = 0;
+#else
+  static const unsigned long BOARD_FLASH_SIZE = FLASH_SIZE;
+#endif
 #endif
 
   /**

--- a/examples/featuresniffer/featuresniffer.ino
+++ b/examples/featuresniffer/featuresniffer.ino
@@ -27,7 +27,7 @@ void setup() {
   Serial.print("-bit, "); Serial.print(ArduinoBoardManager::MAX_MHZ/M);
   Serial.print("Mhz processor with "); Serial.print(ArduinoBoardManager::SRAM_SIZE/k);
   Serial.print("k of SRAM, "); Serial.print(ArduinoBoardManager::EEPROM_SIZE/k);
-  Serial.print("k of EEPROM and "); Serial.print(ArduinoBoardManager::FLASH_SIZE/k);
+  Serial.print("k of EEPROM and "); Serial.print(ArduinoBoardManager::BOARD_FLASH_SIZE/k);
   Serial.println("k of flash.");
   Serial.println();
   


### PR DESCRIPTION
This allows it to compile and run on SAMD boards.